### PR TITLE
Added ability to accept default options from Vue.use call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # vue-scroll-reveal [![license](https://img.shields.io/github/license/tserkov/vue-scroll-reveal.svg)]()
 A Vue directive to wrap [@jlmake](https://github.com/jlmakes)'s excellent [ScrollReveal](https://github.com/jlmakes/scrollreveal) library.
 
-The directive exposes `reset` and `nomobile` as modifiers (ie. `v-scroll-reveal.reset.nomobile`), and all other options can be passed as a value (ie. `v-scroll-reveal={ delay: 250 }`).
+The directive exposes `reset` and `nomobile` as modifiers (ie. `v-scroll-reveal.reset.nomobile`).  
+All other options can be passed to `Vue.use` or to individual elements as a value (ie. `v-scroll-reveal={ delay: 250 }`).
 
 ## Install
 
@@ -22,12 +23,21 @@ yarn add vue-scroll-reveal
 import VueScrollReveal from 'vue-scroll-reveal';
 
 Vue.use(VueScrollReveal);
+
+// You can also pass in default options
+Vue.use(VueScrollReveal, {
+  duration: 800,
+  scale: 1,
+  distance: '10px',
+  mobile: false
+});
 ```
 
 ```html
 <!-- In a component -->
 <template>
   <main>
+
     <section>
       <h1>Scroll down!</h1>
     </section>
@@ -35,6 +45,11 @@ Vue.use(VueScrollReveal);
     <section v-scroll-reveal.reset>
       <h1>Tada!</h1>
     </section>
+
+    <section v-scroll-reveal.reset={ delay: 250 }>
+      <h1>Slightly late tada!</h1>
+    </section>
+
   </main>
 </template>
 
@@ -48,3 +63,15 @@ Vue.use(VueScrollReveal);
 ## Methods
 
 As of 1.0.4, the `isSupported()` and `sync()` are now exposed via `Vue.$sr` or `this.$sr`.
+
+## Nuxt
+
+If using as a plugin with [Nuxt](https://github.com/nuxt/nuxt.js) be sure to disable server side rendering in `nuxt.config.js`.
+
+```javascript
+module.exports = {
+  plugins: [
+    { src: '~/plugins/vue-scroll-reveal', ssr: false }
+  ],
+}
+```

--- a/dist/vue-scroll-reveal.js
+++ b/dist/vue-scroll-reveal.js
@@ -5,8 +5,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 var sr = require('scrollreveal')();
 
-function generateOptions(bindingValue, bindingModifiers) {
-  var options = bindingValue || {};
+function generateOptions(defaultOptions, bindingValue, bindingModifiers) {
+  var options = Object.assign({}, defaultOptions, bindingValue);
 
   if (bindingModifiers) {
     if (bindingModifiers.reset) {
@@ -22,16 +22,16 @@ function generateOptions(bindingValue, bindingModifiers) {
 }
 
 var VueScrollReveal = {
-  install: function install(Vue) {
+  install: function install(Vue, defaultOptions) {
     Vue.directive('scroll-reveal', {
       inserted: function inserted(el, binding) {
-        var options = generateOptions(binding.value);
+        var options = generateOptions(defaultOptions, binding.value, binding.modifiers);
 
         sr.reveal(el, options);
       },
       update: function update(el, binding) {
         if (binding.value != binding.oldValue) {
-          var options = generateOptions(binding.value, binding.modifiers);
+          var options = generateOptions(defaultOptions, binding.value, binding.modifiers);
 
           sr.reveal(el, options);
         }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const sr = require('scrollreveal')();
 
-function generateOptions(bindingValue, bindingModifiers) {
-  const options = bindingValue || {};
+function generateOptions(defaultOptions, bindingValue, bindingModifiers) {
+  const options = Object.assign({}, defaultOptions, bindingValue);
 
   if (bindingModifiers) {
     if (bindingModifiers.reset) {
@@ -17,16 +17,16 @@ function generateOptions(bindingValue, bindingModifiers) {
 }
 
 const VueScrollReveal = {
-  install(Vue) {
+  install(Vue, defaultOptions) {
     Vue.directive('scroll-reveal', {
       inserted: (el, binding) => {
-        const options = generateOptions(binding.value);
+        const options = generateOptions(defaultOptions, binding.value, binding.modifiers);
 
         sr.reveal(el, options);
       },
       update: (el, binding) => {
         if (binding.value != binding.oldValue) {
-          const options = generateOptions(binding.value, binding.modifiers);
+          const options = generateOptions(defaultOptions, binding.value, binding.modifiers);
 
           sr.reveal(el, options);
         }


### PR DESCRIPTION
I wanted an easy way to change defaults on a global level without passing an object into every directive in my components. I think issue #7 is expecting functionality like this and #5 was trying to do something similar but in a different way. 

Also I added a section in the README fixing #3, this is a necessary setting for Nuxt users.