### PR TITLE
Added class property to Vue.use() options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Vue.use(VueScrollReveal, {
   distance: '10px',
   mobile: false
 });
+
+// A class can be added to all elements that are affected by vue-scroll-reveal
+Vue.use(VueScrollReveal, {
+  class: 'v-scroll-reveal',
+  duration: 800,
+  ...
+});
 ```
 
 ```html

--- a/README.md
+++ b/README.md
@@ -26,17 +26,11 @@ Vue.use(VueScrollReveal);
 
 // You can also pass in default options
 Vue.use(VueScrollReveal, {
+  class: 'v-scroll-reveal', // A CSS class applied to elements with the v-scroll-reveal directive; useful for animation overrides.
   duration: 800,
   scale: 1,
   distance: '10px',
   mobile: false
-});
-
-// A class can be added to all elements that are affected by vue-scroll-reveal
-Vue.use(VueScrollReveal, {
-  class: 'v-scroll-reveal',
-  duration: 800,
-  ...
 });
 ```
 

--- a/dist/vue-scroll-reveal.js
+++ b/dist/vue-scroll-reveal.js
@@ -27,6 +27,11 @@ var VueScrollReveal = {
       inserted: function inserted(el, binding) {
         var options = generateOptions(defaultOptions, binding.value, binding.modifiers);
 
+        if (typeof options.class == "string") {
+          el.classList.add(options.class);
+          delete options.class;
+        }
+
         sr.reveal(el, options);
       },
       update: function update(el, binding) {

--- a/dist/vue-scroll-reveal.js
+++ b/dist/vue-scroll-reveal.js
@@ -27,7 +27,7 @@ var VueScrollReveal = {
       inserted: function inserted(el, binding) {
         var options = generateOptions(defaultOptions, binding.value, binding.modifiers);
 
-        if (typeof options.class == "string") {
+        if (typeof options.class === 'string') {
           el.classList.add(options.class);
           delete options.class;
         }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ const VueScrollReveal = {
     Vue.directive('scroll-reveal', {
       inserted: (el, binding) => {
         const options = generateOptions(defaultOptions, binding.value, binding.modifiers);
+        
+        if (typeof options.class == "string"){
+          el.classList.add(options.class);
+          delete options.class;
+        }
 
         sr.reveal(el, options);
       },

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const VueScrollReveal = {
       inserted: (el, binding) => {
         const options = generateOptions(defaultOptions, binding.value, binding.modifiers);
         
-        if (typeof options.class == "string"){
+        if (typeof options.class === 'string') {
           el.classList.add(options.class);
           delete options.class;
         }


### PR DESCRIPTION
Made it possible to specify a class to be added to all elements that have the v-scroll-reveal directive on them. I've found this to be useful for nullifying the reveal effects from css with media queries or when performing visual regression tests.